### PR TITLE
Adapt to new spatstat.random package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     igraph,
     magrittr,
     sf,
-    spatstat.core,
+    spatstat.random,
     spatstat.geom,
     ggthemes,
     methods

--- a/R/PointSim-helpers.R
+++ b/R/PointSim-helpers.R
@@ -17,7 +17,7 @@
 #' @param n the number of points to simulate
 #' @param win a window of class spacejamr to use as the spatial extent
 #'
-#' @return A ppp object from the 'spatstat.core' package that contains
+#' @return A ppp object from the 'spatstat' package that contains
 #' simulated points
 #'
 #' @author Darren Colby
@@ -26,7 +26,7 @@
 poisson_process <- function(n, win) {
 
     # Homogeneous point process
-    point_process <- spatstat.core::rpoint(n = n, win = win)
+    point_process <- spatstat.random::rpoint(n = n, win = win)
 
     return(point_process)
 

--- a/R/PointSim.R
+++ b/R/PointSim.R
@@ -16,7 +16,7 @@
 #' @param a window of class spacejamr to use as the spatial extent
 #' @param seed an optional seed
 #'
-#' @return A ppp object from the 'spatstat.core' package
+#' @return A ppp object from the 'spatstat' package
 #'
 #' @author Darren Colby
 #' Email: dscolby17@gmail.com


### PR DESCRIPTION
Random generators are being moved from `spatstat.core` to a new package `spatstat.random`.
The proposed changes should hopefully fix the upcoming problem for your package.